### PR TITLE
add support for dest_dir_field_name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,6 +99,9 @@ The default size is **1G**.
 |**create_uuid_dir**
 |If set to `true`, each file will get a unique directory with a UUID as its name.
 
+|**dest_dir_field_name**
+|If set, the dest_dir will be set from the specified form value.
+
 |===
 
 === Caddy Variables

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -103,6 +103,10 @@ func (u *Upload) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.Errf("parsing create_uuid_dir: %v", err)
 				}
 				u.CreateUuidDir = uuidDirBool
+			case "dest_dir_field_name":
+				if !d.Args(&u.DestDirFieldName) {
+					return d.ArgErr()
+				}
 			default:
 				return d.Errf("unrecognized servers option '%s'", d.Val())
 			}


### PR DESCRIPTION
this allows to specify `dest_dir` by a form field, for example

```
	upload /upload POST {
		file_field_name file
		dest_dir_field_name dir
	}
```

then in curl:

```
curl -F file=@myfile.data -F dir=some/dir/path/ http://...
```
