### PR TITLE
feat: add pass_thru mode to continue to next handler instead of replying directly

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -102,6 +102,9 @@ The default size is **1G**.
 |**dest_dir_field_name**
 |If set, the dest_dir will be set from the specified form value.
 
+|**pass_thru**
+|If set to `true`, enables pass-thru mode, which continues to the next HTTP handler in the route instead of responding directly.
+
 |===
 
 === Caddy Variables

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -107,6 +107,16 @@ func (u *Upload) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if !d.Args(&u.DestDirFieldName) {
 					return d.ArgErr()
 				}
+			case "pass_thru":
+				var passThruStr string
+				if !d.AllArgs(&passThruStr) {
+					return d.ArgErr()
+				}
+				passThruBool, err := strconv.ParseBool(passThruStr)
+				if err != nil {
+					return d.Errf("parsing pass_thru: %v", err)
+				}
+				u.PassThru = passThruBool
 			default:
 				return d.Errf("unrecognized servers option '%s'", d.Val())
 			}

--- a/upload.go
+++ b/upload.go
@@ -40,6 +40,7 @@ type Upload struct {
 	NotifyMethod     string `json:"notify_method,omitempty"`
 	CreateUuidDir    bool   `json:"create_uuid_dir,omitempty"`
 	DestDirFieldName string `json:"dest_dir_field_name,omitempty"`
+	PassThru         bool   `json:"pass_thru,omitempty"`
 
 	MyTlsSetting struct {
 		InsecureSkipVerify bool   `json:"insecure,omitempty"`
@@ -173,6 +174,7 @@ func (u *Upload) Provision(ctx caddy.Context) error {
 		zap.String("capath", u.MyTlsSetting.CAPath),
 		zap.Bool("insecure", u.MyTlsSetting.InsecureSkipVerify),
 		zap.String("dest_dir_field_name", u.DestDirFieldName),
+		zap.Bool("pass_thru", u.PassThru),
 	)
 
 	return nil
@@ -324,6 +326,10 @@ func (u Upload) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp
 				zap.Error(errNotify),
 			)
 		}
+	}
+
+	if u.PassThru {
+		return next.ServeHTTP(w, r)
 	}
 
 	if u.ResponseTemplate != "" {


### PR DESCRIPTION
We can have the need to not use the reply template, and make our own reply with another handler after this one.
Then we need to skip replying and serve the next handler.